### PR TITLE
Add choreography saga implementation using Spring events

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # saga-example
 
-This project demonstrates an order processing workflow **without** the Saga pattern. It serves as a baseline for later examples that apply the orchestration and choreography Saga patterns.
+This project demonstrates an order processing workflow using the **choreography Saga pattern** implemented with Spring's application events. Each service reacts to domain events and publishes a new event to trigger the next step, allowing the workflow to progress without a central orchestrator.
 
 ## Workflow
-1. Order is created.
-2. Payment is processed.
-3. Shipment is arranged.
-4. Points are earned.
-5. Order is completed.
+1. `OrderService` publishes an `OrderCreatedEvent` when an order is placed.
+2. `PaymentService` marks the order as paid and emits a `PaymentCompletedEvent`.
+3. `ShippingService` schedules shipment and raises a `ShipmentScheduledEvent`.
+4. `PointService` assigns reward points and publishes a `PointsEarnedEvent`.
+5. `OrderService` listens for the `PointsEarnedEvent` and completes the order.
 
 ## Running
 Build and run using Maven:

--- a/src/main/java/com/example/saga/event/OrderCreatedEvent.java
+++ b/src/main/java/com/example/saga/event/OrderCreatedEvent.java
@@ -1,0 +1,6 @@
+package com.example.saga.event;
+
+import com.example.saga.order.Order;
+
+public record OrderCreatedEvent(Order order) {
+}

--- a/src/main/java/com/example/saga/event/PaymentCompletedEvent.java
+++ b/src/main/java/com/example/saga/event/PaymentCompletedEvent.java
@@ -1,0 +1,6 @@
+package com.example.saga.event;
+
+import com.example.saga.order.Order;
+
+public record PaymentCompletedEvent(Order order) {
+}

--- a/src/main/java/com/example/saga/event/PointsEarnedEvent.java
+++ b/src/main/java/com/example/saga/event/PointsEarnedEvent.java
@@ -1,0 +1,6 @@
+package com.example.saga.event;
+
+import com.example.saga.order.Order;
+
+public record PointsEarnedEvent(Order order) {
+}

--- a/src/main/java/com/example/saga/event/ShipmentScheduledEvent.java
+++ b/src/main/java/com/example/saga/event/ShipmentScheduledEvent.java
@@ -1,0 +1,6 @@
+package com.example.saga.event;
+
+import com.example.saga.order.Order;
+
+public record ShipmentScheduledEvent(Order order) {
+}

--- a/src/main/java/com/example/saga/service/OrderService.java
+++ b/src/main/java/com/example/saga/service/OrderService.java
@@ -1,27 +1,30 @@
 package com.example.saga.service;
 
+import com.example.saga.event.OrderCreatedEvent;
+import com.example.saga.event.PointsEarnedEvent;
 import com.example.saga.order.Order;
 import com.example.saga.order.OrderStatus;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
 
 @Service
 public class OrderService {
-    private final PaymentService paymentService;
-    private final ShippingService shippingService;
-    private final PointService pointService;
+    private final ApplicationEventPublisher eventPublisher;
 
-    public OrderService(PaymentService paymentService, ShippingService shippingService, PointService pointService) {
-        this.paymentService = paymentService;
-        this.shippingService = shippingService;
-        this.pointService = pointService;
+    public OrderService(ApplicationEventPublisher eventPublisher) {
+        this.eventPublisher = eventPublisher;
     }
 
     public Order placeOrder(String orderId) {
         Order order = new Order(orderId);
-        paymentService.pay(order);
-        shippingService.ship(order);
-        pointService.earnPoints(order);
-        order.setStatus(OrderStatus.COMPLETED);
+        eventPublisher.publishEvent(new OrderCreatedEvent(order));
         return order;
+    }
+
+    @EventListener
+    public void onPointsEarned(PointsEarnedEvent event) {
+        Order order = event.order();
+        order.setStatus(OrderStatus.COMPLETED);
     }
 }

--- a/src/main/java/com/example/saga/service/PaymentService.java
+++ b/src/main/java/com/example/saga/service/PaymentService.java
@@ -1,13 +1,25 @@
 package com.example.saga.service;
 
+import com.example.saga.event.OrderCreatedEvent;
+import com.example.saga.event.PaymentCompletedEvent;
 import com.example.saga.order.Order;
 import com.example.saga.order.OrderStatus;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
 
 @Service
 public class PaymentService {
-    public void pay(Order order) {
-        // business logic for payment processing
+    private final ApplicationEventPublisher eventPublisher;
+
+    public PaymentService(ApplicationEventPublisher eventPublisher) {
+        this.eventPublisher = eventPublisher;
+    }
+
+    @EventListener
+    public void onOrderCreated(OrderCreatedEvent event) {
+        Order order = event.order();
         order.setStatus(OrderStatus.PAID);
+        eventPublisher.publishEvent(new PaymentCompletedEvent(order));
     }
 }

--- a/src/main/java/com/example/saga/service/PointService.java
+++ b/src/main/java/com/example/saga/service/PointService.java
@@ -1,13 +1,25 @@
 package com.example.saga.service;
 
+import com.example.saga.event.PointsEarnedEvent;
+import com.example.saga.event.ShipmentScheduledEvent;
 import com.example.saga.order.Order;
 import com.example.saga.order.OrderStatus;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
 
 @Service
 public class PointService {
-    public void earnPoints(Order order) {
-        // business logic for earning points
+    private final ApplicationEventPublisher eventPublisher;
+
+    public PointService(ApplicationEventPublisher eventPublisher) {
+        this.eventPublisher = eventPublisher;
+    }
+
+    @EventListener
+    public void onShipmentScheduled(ShipmentScheduledEvent event) {
+        Order order = event.order();
         order.setStatus(OrderStatus.POINTS_EARNED);
+        eventPublisher.publishEvent(new PointsEarnedEvent(order));
     }
 }

--- a/src/main/java/com/example/saga/service/ShippingService.java
+++ b/src/main/java/com/example/saga/service/ShippingService.java
@@ -1,13 +1,25 @@
 package com.example.saga.service;
 
+import com.example.saga.event.PaymentCompletedEvent;
+import com.example.saga.event.ShipmentScheduledEvent;
 import com.example.saga.order.Order;
 import com.example.saga.order.OrderStatus;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
 
 @Service
 public class ShippingService {
-    public void ship(Order order) {
-        // business logic for shipping
+    private final ApplicationEventPublisher eventPublisher;
+
+    public ShippingService(ApplicationEventPublisher eventPublisher) {
+        this.eventPublisher = eventPublisher;
+    }
+
+    @EventListener
+    public void onPaymentCompleted(PaymentCompletedEvent event) {
+        Order order = event.order();
         order.setStatus(OrderStatus.SHIPPED);
+        eventPublisher.publishEvent(new ShipmentScheduledEvent(order));
     }
 }


### PR DESCRIPTION
## Summary
- implement the order workflow as a choreography-style saga driven by Spring application events
- add explicit event types for each step and let services subscribe and publish follow-up events
- document the event-driven flow in the README for seminar reference

## Testing
- `mvn -q test` *(fails: unable to resolve Spring Boot parent POM because the build environment cannot reach Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68c8c9d279a8832181c4a2aad81325a3